### PR TITLE
config: add shared workspace rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,36 @@
+root = true
+
+# All files
+[*]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+# C# Files
+[*.cs]
+# Default C# formatting rules
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+
+# Code Style settings
+dotnet_sort_system_directives_first = true
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+# PowerShell Scripts
+[*.{ps1,psm1,psd1}]
+indent_size = 4
+indent_style = space
+
+# JSON Configuration Files
+[*.json]
+indent_size = 2

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "bracketSpacing": true,
+  "endOfLine": "crlf"
+}
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "[csharp]": {
+        "editor.defaultFormatter": "ms-dotnettools.csharp"
+    },
+    "[powershell]": {
+        "editor.defaultFormatter": "ms-vscode.powershell"
+    },
+    "dotnet.defaultSolution": "WinKey_CommandPalette_Replacement.sln",
+    "omnisharp.enableRoslynAnalyzers": true,
+    "powershell.codeFormatting.Preset": "OTBS"
+}


### PR DESCRIPTION
- Added `.prettierrc` to ensure prettier follows the project's formatting standards
- Added `.editorconfig` to ensure most IDEs follow the project's formatting standards
- Added `.vscode\settings.json` to ensure VS Code follows the project's formatting standards